### PR TITLE
updating vignette to current function name

### DIFF
--- a/vignettes/california-housing.Rmd
+++ b/vignettes/california-housing.Rmd
@@ -90,7 +90,7 @@ length(yhat)
 dim(yhatSamples) #NOTE: Each *column* is a posterior draw
 
 
-mypossum <- additive_summary(summaryform, yhatSamples, yhat, califDf, verbose=TRUE)
+mypossum <- additive_summary_local(summaryform, yhatSamples, yhat, califDf, verbose=TRUE)
 
 additive_summary_plot(mypossum)
 


### PR DESCRIPTION
Was working through your examples and realized the name of `additive_summary()` was recently changed.  Fixing it for myself, but thought I may as well send in the PR too.  

Thanks for the package!