### PR TITLE
adj fastdummies to preserve average_posterior behav

### DIFF
--- a/R/subgroups.R
+++ b/R/subgroups.R
@@ -11,7 +11,7 @@
 ##' 
 subgroup_average_posterior = function(posterior_samples, groups, weights = NULL) {
   
-  gpind = fastDummies::dummy_cols(data.frame(group = factor(groups)))[,-1]
+  gpind = fastDummies::dummy_cols(data.frame(group = factor(groups)))[,-1, drop = TRUE]
   gpind = as.matrix(gpind)
   
   colnames(gpind) = make.names(substring(colnames(gpind), first=7))


### PR DESCRIPTION
Prev commit to improve subgroup_average_posterior() may have inadvertently changed average_posterior()'s behavior--which now outputs a data frame with single column named "out" rather than the seemingly-intended "ATE".  If this was an unintended side effect, this should fix it.